### PR TITLE
Delete variation selectors

### DIFF
--- a/lib/prawn/emoji/drawer.rb
+++ b/lib/prawn/emoji/drawer.rb
@@ -23,6 +23,8 @@ module Prawn
 
       def draw_emoji(text, text_options)
         left_text, emoji_unicode, remaining_text = text.partition(@emoji_index.to_regexp)
+        # Delete variation selector character
+        remaining_text.delete!("\ufe0f")
 
         return text if emoji_unicode.empty?
 

--- a/lib/prawn/emoji/version.rb
+++ b/lib/prawn/emoji/version.rb
@@ -2,6 +2,6 @@
 
 module Prawn
   module Emoji
-    VERSION = '2.0.1'.freeze
+    VERSION = '2.0.2'.freeze
   end
 end


### PR DESCRIPTION
When converting some emojis to images emojis (such as ❤️ ), it leaves a trailing square character just after the image.

According to https://apps.timwhitlock.info/unicode/inspect?s=%E2%9D%A4%EF%B8%8F some emojis have an extra `variation selector` character. Deleting that character from the `remaining text` looks like solving the issue.
