### PR TITLE
Emoji Regex is now configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Minor Enhancements
 
  * Ruby 2.7.0 support
+ * Emoji Regex can now be overridden in `Prawn::Emoji.config.regex`
 
 ## 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ require 'prawn/emoji'
 
 In order to draw Emoji, you must use a True Type Font. I recommend you use a Japanese font.
 
+## Configuring Emoji Regex
+
+Emoji Regex is a regular expression used to determine which emoji to draw.
+
+```ruby
+Prawn::Emoji.config.regex # => ::Unicode::Emoji::REGEX_VALID by default
+```
+
+You can override it with [unicode-emoji's Regex](https://github.com/janlelis/unicode-emoji#regex):
+
+```ruby
+Prawn::Emoji.config.regex = ::Unicode::Emoji::REGEX_INCLUDE_TEXT
+```
+
+
 ## Supported Versions
 
 ### Ruby

--- a/lib/prawn/emoji.rb
+++ b/lib/prawn/emoji.rb
@@ -1,12 +1,25 @@
 # frozen_string_literal: true
 
 require 'prawn'
-require 'pathname'
 require 'unicode/emoji'
+require 'pathname'
 
 module Prawn
   module Emoji
-    REGEX = ::Unicode::Emoji::REGEX_VALID
+    Config = Struct.new(
+      # Emoji Regex
+      #
+      # The following values are available (Default is `Unicode::Emoji::REGEX_VALID`):
+      # https://github.com/janlelis/unicode-emoji#regex.
+      :regex
+    )
+    def self.config
+      @config ||= Config.new(::Unicode::Emoji::REGEX_VALID)
+    end
+
+    def self.regex
+      config.regex
+    end
 
     def self.root
       @root ||= Pathname.new File.expand_path('../..', File.dirname(__FILE__))

--- a/lib/prawn/emoji/drawer.rb
+++ b/lib/prawn/emoji/drawer.rb
@@ -15,7 +15,7 @@ module Prawn
 
       def draw(text, text_options)
         return text unless text.encoding == ::Encoding::UTF_8
-        return text unless Emoji::REGEX.match?(text)
+        return text unless Emoji.regex.match?(text)
 
         result = []
         target = Emoji::Text.new(text)

--- a/lib/prawn/emoji/text.rb
+++ b/lib/prawn/emoji/text.rb
@@ -27,7 +27,7 @@ module Prawn
       private
 
       def partition_by_emoji(text)
-        text.partition(Emoji::REGEX)
+        text.partition(Emoji.regex)
       end
     end
   end

--- a/test/units/prawn/emoji_test.rb
+++ b/test/units/prawn/emoji_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'units/test_helper'
+
+describe Prawn::Emoji do
+  describe '.regex' do
+    subject { Prawn::Emoji.regex }
+
+    describe 'Default' do
+      it { _(subject).must_equal ::Unicode::Emoji::REGEX_VALID }
+    end
+
+    describe 'Custom' do
+      let(:custom_regex) { ::Unicode::Emoji::REGEX_INCLUDE_TEXT }
+
+      before { stub(Prawn::Emoji.config).regex { custom_regex } }
+
+      it { _(subject).must_equal custom_regex }
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #28 by making Emoji Regex configurable.

```ruby
Prawn::Emoji.config.regex #=> ::Unicode::Emoji::REGEX_VALID by default

Prawn::Emoji.config.regex = ::Unicode::Emoji::REGEX_INCLUDE_TEXT
Prawn::Emoji.config.regex #=> ::Unicode::Emoji::REGEX_INCLUDE_TEXT
```