### PR TITLE
Close opened image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
  * Ruby 2.7.0 support
 
+### Bug Fixes
+
+ * Close opened image file #31
+
 ## 3.1.0
 
 ### Minor Enhancements

--- a/lib/prawn/emoji/drawer.rb
+++ b/lib/prawn/emoji/drawer.rb
@@ -50,7 +50,16 @@ module Prawn
         x = image.adjust_x(base_x + @document.width_of(base_text + text.left, text_options))
         y = image.adjust_y(base_y)
 
-        @document.image image.path, at: [x, y], width: image.width
+        # Prawn 2.2 does not close the image file when Pathname is passed to Document#image method.
+        #
+        # FIXME: This issue has been fixed by https://github.com/prawnpdf/prawn/pull/1090 but not released.
+        # Fix as follows after the PR released.
+        #
+        #   @document.image(image_file.path, at: [x, y], width: image.width)
+        #
+        File.open(image.path, 'r') do |image_file|
+          @document.image(image_file, at: [x, y], width: image.width)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes #29. See description of #29 for details.

```ruby
require 'prawn/emoji'

Prawn::Document.generate 'sushi.pdf' do
  font 'DejaVuSans.ttf'
  text '🐟 / 🔪 + 🍚 / 🍾 = 🍣'
end

ObjectSpace.each_object(File) do |f|
  puts "%s: %d" % [f.path, f.fileno] unless f.closed?
end

DejaVuSans.ttf: 26
prawn-emoji-3.1.0/emoji/images/1f35a.png: 29
prawn-emoji-3.1.0/emoji/images/1f37e.png: 30
prawn-emoji-3.1.0/emoji/images/1f363.png: 31
prawn-emoji-3.1.0/emoji/images/1f41f.png: 27
prawn-emoji-3.1.0/emoji/images/1f52a.png: 28
```

prawn-emoji just passes the path of image file to `Prawn#image` method but not open image file.
https://github.com/hidakatsuya/prawn-emoji/blob/26f83a1c31c70642291d3b2d4a2ddff6379dbe57/lib/prawn/emoji/drawer.rb#L53

Image files are opened by prawn. See https://github.com/prawnpdf/prawn/issues/975 for details. This issue has been already fixed by https://github.com/prawnpdf/prawn/pull/1090, but not released yet.

The GC should close the file, but fix it so that it explicitly closes the file.