### PR TITLE
Add prawn 2.3.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Test on ruby ${{ matrix.ruby_version }}
+    name: Test on ruby ${{ matrix.ruby_version }} and prawn ${{ matrix.prawn_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -12,8 +12,13 @@ jobs:
           - 2.5.x
           - 2.6.x
           - 2.7.x
+        prawn_version:
+          - 2.2
+          - 2.3
+
     steps:
     - uses: actions/checkout@v1
+
     - name: Set up diff-pdf
       run: |
         sudo apt-get update
@@ -21,12 +26,14 @@ jobs:
         git clone https://github.com/vslavik/diff-pdf.git -b v0.4.1 --depth 1 /tmp/diff-pdf-src
         cd /tmp/diff-pdf-src
         ./bootstrap && ./configure && make && sudo make install
+
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+
     - name: Build and test with Rake
       run: |
         gem install bundler
-        bundle install --jobs 4 --retry 3
+        bundle install --gemfile test/gemfiles/prawn-${{ matrix.prawn_version }} --jobs 4 --retry 3
         bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Prawn::Emoji.config.regex = ::Unicode::Emoji::REGEX_INCLUDE_TEXT
 
 ### Prawn
 
-2.2+
+2.2, 2.3
 
 ## Contributing
 

--- a/lib/prawn/emoji/drawer.rb
+++ b/lib/prawn/emoji/drawer.rb
@@ -58,21 +58,9 @@ module Prawn
 
       def draw_emoji(emoji_char, at:)
         emoji_image = Emoji::Image.new(emoji_char)
+        emoji_image.render(document, at: at)
 
-        x, y = at
-
-        # Prawn 2.2 does not close the image file when Pathname is passed to Document#image method.
-        #
-        # FIXME: This issue has been fixed by https://github.com/prawnpdf/prawn/pull/1090 but not released.
-        # Fix as follows after the PR released.
-        #
-        #   @document.image(image_file.path, at: [x, y], width: image.width)
-        #
-        File.open(emoji_image.path, 'rb') do |image_file|
-          @document.image(image_file, at: [x, y + emoji_char.height], width: emoji_char.width)
-        end
-
-        emoji_char.width + document.character_spacing
+        emoji_image.width + document.character_spacing
       end
     end
   end

--- a/lib/prawn/emoji/drawer.rb
+++ b/lib/prawn/emoji/drawer.rb
@@ -44,7 +44,16 @@ module Prawn
 
       def draw_text(text, at:, text_options:)
         draw_text!(text, at: at, text_options: text_options)
-        document.width_of(text, text_options)
+
+        width = document.width_of(text, text_options)
+
+        if Prawn::VERSION >= '2.3.0'
+          # In prawn v2.3.0, the character spacing at the end of the text is not included in the calculated text width.
+          # https://github.com/prawnpdf/prawn/pull/1117
+          width > 0 ? width + document.character_spacing : width
+        else
+          width
+        end
       end
 
       def draw_emoji(emoji_char, at:)

--- a/lib/prawn/emoji/image.rb
+++ b/lib/prawn/emoji/image.rb
@@ -1,12 +1,34 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module Prawn
   module Emoji
     class Image
+      extend Forwardable
+
       STORE = Emoji.root.join 'emoji', 'images'
+
+      def_delegators :emoji_char, :width, :height
 
       def initialize(emoji_char)
         @emoji_char = emoji_char
+      end
+
+      def render(document, at:)
+        x, y = at
+
+        position = [x, y + height]
+
+        if Prawn::VERSION >= '2.3.0'
+          document.image(path, at: position, width: width)
+        else
+          # Prawn 2.2 does not close the image file when Pathname is passed to Document#image method.
+          # https://github.com/prawnpdf/prawn/pull/1090
+          File.open(path, 'rb') do |image_file|
+            document.image(image_file, at: position, width: width)
+          end
+        end
       end
 
       def path

--- a/prawn-emoji.gemspec
+++ b/prawn-emoji.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_path  = 'lib'
 
-  spec.add_runtime_dependency 'prawn', '~> 2.2.0'
+  spec.add_runtime_dependency 'prawn', '~> 2.2'
   spec.add_runtime_dependency 'unicode-emoji', '~> 2.5.0'
 end

--- a/test/gemfiles/prawn-2.2
+++ b/test/gemfiles/prawn-2.2
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'prawn', '~> 2.2.0'
+gem 'unicode-emoji', '~> 2.5.0'
+
+gem 'rake', '>= 0'
+gem 'minitest', '>= 5.12.2'
+gem 'rr', '>= 0'
+gem 'rubyzip', '>= 1.0.0'
+

--- a/test/gemfiles/prawn-2.3
+++ b/test/gemfiles/prawn-2.3
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'prawn', '~> 2.3.0'
+gem 'unicode-emoji', '~> 2.5.0'
+
+gem 'rake', '>= 0'
+gem 'minitest', '>= 5.12.2'
+gem 'rr', '>= 0'
+gem 'rubyzip', '>= 1.0.0'
+

--- a/test/units/prawn/emoji/drawer_test.rb
+++ b/test/units/prawn/emoji/drawer_test.rb
@@ -24,7 +24,8 @@ describe Prawn::Emoji::Drawer do
 
     it do
       mock(document).draw_text!(/aaa|bbb|ccc|/, hash_including(emoji: false)).times(4)
-      mock(document).image(is_a(File), is_a(Hash)).times(3)
+      any_instance_of(Prawn::Emoji::Image) { |image| mock(image).render.with_any_args.times(3) }
+
       subject
     end
   end
@@ -35,7 +36,8 @@ describe Prawn::Emoji::Drawer do
 
     it do
       mock(document).draw_text!(text, text_options.merge(emoji: false)).once
-      mock(document).image.never
+      any_instance_of(Prawn::Emoji::Image) { |image| mock(image).render.with_any_args.never }
+
       subject
     end
   end

--- a/test/units/prawn/emoji/drawer_test.rb
+++ b/test/units/prawn/emoji/drawer_test.rb
@@ -84,11 +84,31 @@ describe Prawn::Emoji::Drawer do
     describe '#draw_text' do
       subject { drawer.send(:draw_text, text, at: [100, 200], text_options: {}) }
 
-      let(:text) { 'text' }
+      let(:character_spacing) { 5 }
 
-      it 'returns the text width' do
-        stub(document).character_spacing { 5 }
-        _(subject).must_equal document.width_of(text)
+      before { stub(document).character_spacing { character_spacing } }
+
+      describe 'text is empty' do
+        let(:text) { '' }
+
+        it 'returns 0 when the text is empty' do
+          _(subject).must_equal 0
+        end
+      end
+
+      describe 'text is not empty' do
+        let(:text) { 'text' }
+
+        it 'returns the text width including the character spacing at the end of the text' do
+          expect_width =
+            if Prawn::VERSION >= '2.3.0'
+              document.width_of(text) + character_spacing
+            else
+              document.width_of(text)
+            end
+
+          _(subject).must_equal expect_width
+        end
       end
     end
   end

--- a/test/units/prawn/emoji/image_test.rb
+++ b/test/units/prawn/emoji/image_test.rb
@@ -14,4 +14,31 @@ describe Prawn::Emoji::Image do
       end
     end
   end
+
+  describe '#width and #height' do
+    let(:emoji_image) { Prawn::Emoji::Image.new(emoji_char) }
+    let(:emoji_char) { Prawn::Emoji::Char.new('🍣', 12) }
+
+    before do
+      stub(emoji_char).width { 14 }
+      stub(emoji_char).height { 18 }
+    end
+
+    it do
+      _(emoji_image.width).must_equal 14
+      _(emoji_image.height).must_equal 18
+    end
+  end
+
+  describe '#render' do
+    let(:emoji_image) { Prawn::Emoji::Image.new(Prawn::Emoji::Char.new('🍣', 12)) }
+
+    it do
+      document = Prawn::Document.new
+
+      mock(document).image.with_any_args.times(1)
+
+      emoji_image.render(document, at: [100, 200])
+    end
+  end
 end


### PR DESCRIPTION
prawn 2.3.0 has been released at August 1, 2020.
https://github.com/prawnpdf/prawn/blob/master/CHANGELOG.md#prawnpdf-230

I test and implement to support it.